### PR TITLE
New Feature: Rush Typescript SDK: Solana Storage Class

### DIFF
--- a/ecs/web/sdk/typescript/.gitignore
+++ b/ecs/web/sdk/typescript/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+bun.lockb
+package-lock.json
+.env

--- a/ecs/web/sdk/typescript/.gitignore
+++ b/ecs/web/sdk/typescript/.gitignore
@@ -3,3 +3,5 @@ dist
 bun.lockb
 package-lock.json
 .env
+SAMPLE_PAIR.json
+*.js

--- a/ecs/web/sdk/typescript/package.json
+++ b/ecs/web/sdk/typescript/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "typescript",
+  "version": "1.0.0",
+  "main": "src/index.ts",
+  "scripts": {
+    "dev": "tsc --watch & nodemon dist/index.js",
+    "build": "npx tsc",
+    "start": "node dist/index.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": "",
+  "devDependencies": {
+    "nodemon": "^3.1.9",
+    "typescript": "^5.7.2"
+  },
+  "dependencies": {
+    "@solana-developers/helpers": "^2.5.6",
+    "@solana/web3.js": "^1.95.8",
+    "esrun": "^3.2.26"
+  }
+}

--- a/ecs/web/sdk/typescript/src/index.ts
+++ b/ecs/web/sdk/typescript/src/index.ts
@@ -1,0 +1,8 @@
+const set : string = 'bum'
+
+console.log(set)
+
+
+let momo : number = 12
+
+console.log(momo + 1)

--- a/ecs/web/sdk/typescript/src/index.ts
+++ b/ecs/web/sdk/typescript/src/index.ts
@@ -1,8 +1,28 @@
-const set : string = 'bum'
+import { Keypair, PublicKey } from "@solana/web3.js";
+import { Solana } from "./modules/storage";
 
-console.log(set)
+// ? this is a mock test
+// ? this is where the solana storage class is called inside the TS_RUSH_SDK
+
+function test_call_storage() {
+  const new_keypair = Keypair.generate();
+
+  const storage = new Solana({
+    blueprint: "/my/blueprint/path",
+    program_id: new PublicKey("6vg3oUN7LLcCS3Qc8bhsrqqJRkeDaC2KsFqF23aQp5iQ"),
+    signer: new_keypair,
+    rpc_url: "http://127.0.0.1:8899",
+  });
+
+  console.log(storage);
+  console.log("signer :", {
+    "pubkey :": storage.signer.publicKey,
+    "sec key :": storage.signer.secretKey,
+  });
+  console.log(storage.signer.secretKey);
+}
+
+// test_call_storage();
 
 
-let momo : number = 12
-
-console.log(momo + 1)
+console.log('sdk index file')

--- a/ecs/web/sdk/typescript/src/modules/blueprint/index.ts
+++ b/ecs/web/sdk/typescript/src/modules/blueprint/index.ts
@@ -1,0 +1,43 @@
+//? this is a placeholder class for BtreeMap, module to be developed? or is it a library?
+
+import { bluePrint, bTreeMap } from "../../types";
+
+class BTreeMap implements bTreeMap {
+  //! should use collections library for this
+
+  K;
+  V;
+  A;
+
+  constructor(K: string = "", V: string = "", A: string = "") {
+    this.K = K;
+    this.V = V;
+    this.A = A;
+  }
+}
+
+export class BluePrint implements bluePrint {
+  name;
+  description;
+  entities;
+  regions;
+  instances;
+  // description: world_description,
+  // entities: BTreeMap::new(),
+  // regions: BTreeMap::new(),
+  // instances: BTreeMap::new(),
+
+  constructor(
+    name: string,
+    description: string,
+    entities: BTreeMap = new BTreeMap(),
+    regions: BTreeMap = new BTreeMap(),
+    instances: BTreeMap = new BTreeMap()
+  ) {
+    this.name = name;
+    this.description = description;
+    this.entities = entities;
+    this.regions = regions;
+    this.instances = instances;
+  }
+}

--- a/ecs/web/sdk/typescript/src/modules/storage/index.ts
+++ b/ecs/web/sdk/typescript/src/modules/storage/index.ts
@@ -1,21 +1,124 @@
+import { Keypair, PublicKey } from "@solana/web3.js";
+import { solanaStorage } from "../../types";
+import * as fs from "fs";
+import * as path from "path";
+
 // ! in this solana
 
-
-// ? use solana client : rpc client, rpc client  
-// ! 
+// ? use solana client : rpc client, rpc client
+// !
 
 // ! solana sdk :
 // ? pubkey,
 // ? signer: { keypair, keypair, signer }
-// ? transaction 
+// ? transaction
 
 // ! impl solana {
 // !  pub fn new(progam id: pubkey, signer: keypair, rpc_url: string, path: )
 // ! }
+export class Solana implements solanaStorage {
+  blueprint;
+  program_id;
+  signer;
+  rpc_url;
 
+  constructor({ blueprint, program_id, signer, rpc_url }: solanaStorage) {
+    let Path = "";
 
-class Solana {
-    constructor() {
-        
-    }
+    let bluprint = (this.blueprint = blueprint);
+    this.program_id = program_id;
+    this.signer = signer;
+    this.signer = signer;
+    this.rpc_url = rpc_url;
+  }
+
+  /**
+   * migrate function
+   * /// TODO: DONE RULE: The Game Developer must be able to create an onchain world and
+   * spawn its initial entities based on the Rush Gaming Blueprint configuration
+   */
+  public migrate() {
+    console.log(this.migrate);
+  }
+
+  /**
+   * create function
+   * /// TODO: DONE RULE: The Game Developer must be able to spawn an entity on the
+   * onchain game world in the Rush Store Solana Program (smart contract) after instantiating the SDK
+   */
+  public create() {
+    console.log("create method");
+  }
+
+  /**
+   * delete function
+   */
+  public delete() {
+    console.log("delete method");
+  }
+
+  /**
+   * get function
+   * /// TODO: DONE RULE: The Game Developer must be able to retrieve specific entity
+   * data from their game’s On-chain world
+   */
+  public get() {
+    console.log("get method");
+  }
+
+  /**
+   * set function
+   * /// TODO: DONE RULE: The Game Developer must be able to update a specific entity data
+   * from their game’s Onchain world
+   */
+  public set() {
+    console.log("set method");
+  }
 }
+
+function test() {
+  let Path = "";
+  let PubKey = "";
+  let KEYPAIR: Keypair;
+  let KEYPAIR_JSON;
+
+  //! declare a keypair in a json file named <> with a publicKey and secretKey value pair
+
+  // ? this one should be dynamic, auto generated after a sign-in of the wallet is engaged
+  const KEYPAIR_PATH = path.join(__dirname, "SAMPLE_PAIR.json");
+  Path = KEYPAIR_PATH;
+
+  if (!fs.existsSync(KEYPAIR_PATH)) {
+    KEYPAIR = Keypair.generate();
+    const KEYPAIR_JSON = JSON.stringify({
+      publicKey: KEYPAIR.publicKey.toString(),
+      secretKey: Array.from(KEYPAIR.secretKey),
+    });
+
+    fs.writeFileSync(KEYPAIR_PATH, KEYPAIR_JSON);
+    // notice
+    console.log("New keypair generated and saved to", KEYPAIR_PATH);
+  } else {
+    const KEYPAIR_JSON = JSON.parse(fs.readFileSync(KEYPAIR_PATH, "utf-8"));
+    const SECRET_KEY = Uint8Array.from(KEYPAIR_JSON.secretKey);
+    KEYPAIR = Keypair.fromSecretKey(SECRET_KEY);
+    PubKey = KEYPAIR.publicKey.toBase58();
+    // notice
+    console.log("Loaded keypair with public key:", PubKey);
+  }
+
+  // let program_id = new PublicKey(PubKey);
+  const program_id = KEYPAIR.publicKey;
+
+  const storage = new Solana({
+    blueprint: "/path/to/blueprint",
+    program_id: program_id.toString(),
+    signer: KEYPAIR,
+    rpc_url: "http://127.0.0.1:8899",
+  });
+}
+
+// ! WARNING: Test should not be in development environment
+// ! Do it with build and start, not dev so the loop won't happen
+// * uncomment if trying to tes
+// test();

--- a/ecs/web/sdk/typescript/src/modules/storage/index.ts
+++ b/ecs/web/sdk/typescript/src/modules/storage/index.ts
@@ -1,0 +1,21 @@
+// ! in this solana
+
+
+// ? use solana client : rpc client, rpc client  
+// ! 
+
+// ! solana sdk :
+// ? pubkey,
+// ? signer: { keypair, keypair, signer }
+// ? transaction 
+
+// ! impl solana {
+// !  pub fn new(progam id: pubkey, signer: keypair, rpc_url: string, path: )
+// ! }
+
+
+class Solana {
+    constructor() {
+        
+    }
+}

--- a/ecs/web/sdk/typescript/src/types/index.d.ts
+++ b/ecs/web/sdk/typescript/src/types/index.d.ts
@@ -1,0 +1,35 @@
+import { Keypair, PublicKey } from "@solana/web3.js";
+
+export enum rpcUrl {
+    Devnet = "https://api.devnet.solana.com",
+    Mainnet = "https://api.mainnet-beta.solana.com",
+    Testnet = "https://api.testnet.solana.com",
+    Local = "http://127.0.0.1:8899",
+  }
+  
+  export interface bTreeMap {
+    K: string;
+    V: string;
+    A: string;
+  }
+  
+  export interface bluePrint {
+    name: string;
+    description: string;
+    entities: bTreeMap;
+    regions: bTreeMap;
+    instances: bTreeMap;
+  }
+  
+  export interface solanaStorage {
+    blueprint: string;
+    program_id: PublicKey | string;
+    signer: Keypair;
+    rpc_url: string;
+  }
+  
+  export interface Signer {
+    publicKey: PublicKey;
+    secretKey: Uint8Array;
+  }
+  

--- a/ecs/web/sdk/typescript/tsconfig.json
+++ b/ecs/web/sdk/typescript/tsconfig.json
@@ -1,0 +1,123 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig to read more about this file */
+
+    /* Projects */
+    // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
+    // "composite": true,                                /* Enable constraints that allow a TypeScript project to be used with project references. */
+    // "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
+    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
+    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
+    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
+
+    /* Language and Environment */
+    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
+    // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
+    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
+    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
+    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
+    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
+    // "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
+    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
+    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
+    // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
+
+    /* Modules */
+    "module": "ES6",                                /* Specify what module code is generated. */
+    // "module": "commonjs",                                /* Specify what module code is generated. */
+    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
+    // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
+    // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
+    // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
+    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
+    // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
+    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
+    // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
+    // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */
+    // "rewriteRelativeImportExtensions": true,          /* Rewrite '.ts', '.tsx', '.mts', and '.cts' file extensions in relative import paths to their JavaScript equivalent in output files. */
+    // "resolvePackageJsonExports": true,                /* Use the package.json 'exports' field when resolving package imports. */
+    // "resolvePackageJsonImports": true,                /* Use the package.json 'imports' field when resolving imports. */
+    // "customConditions": [],                           /* Conditions to set in addition to the resolver-specific defaults when resolving imports. */
+    // "noUncheckedSideEffectImports": true,             /* Check side effect imports. */
+    // "resolveJsonModule": true,                        /* Enable importing .json files. */
+    // "allowArbitraryExtensions": true,                 /* Enable importing files with any extension, provided a declaration file is present. */
+    // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
+
+    /* JavaScript Support */
+    // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
+    // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
+    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
+
+    /* Emit */
+    "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
+    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
+    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
+    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
+    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
+    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
+    // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
+    // "removeComments": true,                           /* Disable emitting comments. */
+    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
+    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
+    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
+    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
+    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
+    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
+    // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
+    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
+    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+    // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
+    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
+
+    /* Interop Constraints */
+    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
+    // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
+    // "isolatedDeclarations": true,                     /* Require sufficient annotation on exports so other tools can trivially generate declaration files. */
+    // "allowSyntheticDefaultImports": true,             /* Allow 'import x from y' when a module doesn't have a default export. */
+    "esModuleInterop": true,                             /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */
+    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
+    "forceConsistentCasingInFileNames": true,            /* Ensure that casing is correct in imports. */
+
+    /* Type Checking */
+    "strict": true,             
+                             /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
+    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
+    // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
+    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
+    // "strictBuiltinIteratorReturn": true,              /* Built-in iterators are instantiated with a 'TReturn' type of 'undefined' instead of 'any'. */
+    // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
+    // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
+    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
+    // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
+    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
+    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
+    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
+    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
+    // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
+    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
+    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
+    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
+    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
+
+    /* Completeness */
+    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
+    "skipLibCheck": true,                                 /* Skip type checking all .d.ts files. */
+    "noFallthroughCasesInSwitch": true,
+    "outDir": "./dist",                      // Output the compiled files into the `dist` directory
+    "rootDir": "./src",
+    "types": ["./src/types/types.d.ts"]
+  },
+  "include": [
+    "src/**/*.ts"                            // Include all .ts files in the `src` folder
+  ],
+  "exclude": [
+    "node_modules"                           // Exclude node_modules from the compilation
+  ]
+} 

--- a/ecs/web/sdk/typescript/tsconfig.json
+++ b/ecs/web/sdk/typescript/tsconfig.json
@@ -11,8 +11,8 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es2016",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
-    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
+    "target": "ES2020",                                  /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */
+    "lib": ["ES2020", "DOM"],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
     // "jsx": "preserve",                                /* Specify what JSX code is generated. */
     // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
     // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
@@ -25,10 +25,10 @@
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
 
     /* Modules */
-    "module": "ES6",                                /* Specify what module code is generated. */
+    "module": "NodeNext",                                /* Specify what module code is generated. */
     // "module": "commonjs",                                /* Specify what module code is generated. */
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
+    "moduleResolution": "nodenext",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
@@ -108,13 +108,14 @@
 
     /* Completeness */
     // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
-    "skipLibCheck": true,                                 /* Skip type checking all .d.ts files. */
-    "noFallthroughCasesInSwitch": true,
+    // "skipLibCheck": true,                                 /* Skip type checking all .d.ts files. */
+    // "noFallthroughCasesInSwitch": true,
     "outDir": "./dist",                      // Output the compiled files into the `dist` directory
     "rootDir": "./src",
-    "types": ["./src/types/types.d.ts"]
+    "types": ["./src/types/index.d.ts", "node"]
   },
   "include": [
+    "*/.d.ts",                            // Include all .ts files in the `src` folder
     "src/**/*.ts"                            // Include all .ts files in the `src` folder
   ],
   "exclude": [


### PR DESCRIPTION
# Description

This is a feature to enable the game developers using the Rush SDK done in Typescript. Starting with the component. The storage class is initialized and made the placeholder for its methods to connect to the actual solana program.

# Link to issue

`notion: card:: ts sdk:: solana storage`

# Type of change

- [x] New feature (non-breaking change that adds functionality)
- [x] This change requires a documentation update

# Test plan (required)

This is still in development with collaboration with my co-candidates of JRBE

### To start testing, from the project go to dir:
#### - `cd ecs/web/sdk/typescript`
###  Install the dependencies 
#### - `npm i`

### While in development, you may enable dev environment by
### - `npm run dev`

## To start the function running and do function testing, go the file '/src/index.ts'
### In the _src_ file
- uncomment the line `test_call_storage()` to test out calling the class 
### In the _modules/storage/_ file
- uncomment the line `test()` to test out this class

### To test, build it first and start
#### - `npm run build && npm run start`



# Screenshots/Screencaps

## This is a screenshot showing the success of initializing the Solana Class and returns the four parameters required to be processed inside the class when you uncomment the `test_call_storage()`
![image](https://github.com/user-attachments/assets/cdbf557f-3404-4761-8f7c-98077d86a3d8)

